### PR TITLE
Show Favourites In Modal

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -22,6 +22,7 @@ const App = () => {
     isFavourite,
     isThereAFavourite,
     showModal,
+    toggleFavModal,
     getPhotosById,
     selected,
     state
@@ -37,12 +38,14 @@ const App = () => {
           isFavourite={isFavourite}
           selected={selected}
           toggleFavourite={toggleFavourite}
+          showFavModal={state.showFavModal}
         />}
       <HomeRoute
         photos={state.photoData}
         topics={state.topicData}
         getPhotosById={getPhotosById}
         showModal={showModal}
+        toggleFavModal={() => toggleFavModal()}
         isFavourite={isFavourite}
         toggleFavourite={toggleFavourite}
         isThereAFavourite={isThereAFavourite()}

--- a/frontend/src/components/FavBadge.jsx
+++ b/frontend/src/components/FavBadge.jsx
@@ -5,7 +5,7 @@ import '../styles/FavBadge.scss';
 
 const FavBadge = (props) => {
   return (
-    <div className='fav-badge'>
+    <div className='fav-badge' onClick={props.toggleFavModal}>
       <FavIcon
         selected={props.isThereAFavourite}
         displayAlert={props.isThereAFavourite}

--- a/frontend/src/components/PhotoList.jsx
+++ b/frontend/src/components/PhotoList.jsx
@@ -8,14 +8,14 @@ const PhotoList = (props) => {
   const displayRelated = props.displayType === "related";
 
   //map over the photos and create an item
-  const listOfPhotos = props.photos.map(item => {
+  const listOfPhotos = props.photos.map((item, index) => {
 
     const selected = props.isFavourite(item.id);
 
     return (
       <PhotoListItem
         //from the DB
-        key={item.id}
+        key={index}
         photoId={item.id}
         location={item.location}
         imageSourceRegular={item.urls.regular}

--- a/frontend/src/components/TopNavigationBar.jsx
+++ b/frontend/src/components/TopNavigationBar.jsx
@@ -11,6 +11,7 @@ const TopNavigation = (props) => {
       <TopicList topics={props.topics} getPhotosById={props.getPhotosById}></TopicList>
       {/* Shows a badge in Nav if there is ANY favourited item */}
       <FavBadge
+        toggleFavModal={props.toggleFavModal}
         isThereAFavourite={props.isThereAFavourite}
       />
     </div>

--- a/frontend/src/routes/HomeRoute.jsx
+++ b/frontend/src/routes/HomeRoute.jsx
@@ -11,6 +11,7 @@ const HomeRoute = (props) => {
         topics={props.topics}
         isThereAFavourite={props.isThereAFavourite}
         getPhotosById={props.getPhotosById}
+        toggleFavModal={props.toggleFavModal}
       />
       <PhotoList
         photos={props.photos}

--- a/frontend/src/routes/PhotoDetailsModal.jsx
+++ b/frontend/src/routes/PhotoDetailsModal.jsx
@@ -73,7 +73,9 @@ const PhotoDetailsModal = (props) => {
         {...props.photoInfo}
       />
 
-      <div className="photo-details-modal__header">Related Photos</div>
+      <div className="photo-details-modal__header">
+        {props.showFavModal ? "Other Favourites" : "Show Related Photos"}
+      </div>
 
       <div className="photo-details-modal__images">
         <PhotoList


### PR DESCRIPTION
Some improvements I think I can make:

1.) showModal is tied to photoInfo, where it should have been separate.  Right now when I open the modal from the perspective of 'show only favourites', it uses the photoInfo logic to open it, which isn't what it was designed for.

2.) The time it takes to toggle the favourite function is O(m x n), m = # of favs, n = number of total photos.  It could be more efficient if we persist liked photos into DB and then queried from it.

3.) Reconstructing the photo object in two different places...one in useAppData and another in PhotoListItem.  Ideally, we shouldn't have to reconstruct in the first place.  I did it so we tell the modal which object to focus on.

4.) The layout of the 'focused' modal and the 'liked photos only' are virtually the same, except for the label.  We'll just say it's a 'design choice :)'.